### PR TITLE
Update max_session_duration in AWS IAM role

### DIFF
--- a/aws/iam_role.tf
+++ b/aws/iam_role.tf
@@ -105,7 +105,7 @@ POLICY
 
   description = "Service provider managed role for deployment of terraform resources"
   managed_policy_arns  = []
-  max_session_duration = "1800"
+  max_session_duration = "3600"
   name                 = "omnistrate-terraform-role"
   path                 = "/"
 }


### PR DESCRIPTION
Running a `terraform plan` on master returns the following output:

```
terraform plan
╷
│ Error: expected max_session_duration to be in the range (3600 - 43200), got 1800
│ 
│   with aws_iam_role.omnistrate-terraform-role,
│   on iam_role.tf line 108, in resource "aws_iam_role" "omnistrate-terraform-role":
│  108:   max_session_duration = "1800"
│ 
╵
```

`max_session_duration` needs to be a minimum of `3600` to apply.